### PR TITLE
feat(filtering): Bump FirestoreStorage dependency and enable Firestore Filter capabilities

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "reflect-metadata": "^0.1.13",
-    "ts-object-path": "^0.1.2"
+    "ts-object-path": "^0.1.2",
+    "@google-cloud/firestore": "^7.11.0"
   },
   "gitHead": "0b06debcfa978dcfd12f74599cded3802179e34b"
 }

--- a/packages/core/src/storage/query.ts
+++ b/packages/core/src/storage/query.ts
@@ -1,14 +1,19 @@
 import { BaseModel, ModelQuery } from './types';
 import { getPath } from 'ts-object-path';
+import { Filter } from '@google-cloud/firestore';
 
 export type WhereProp<T extends BaseModel> = string | ((t: T) => unknown);
 
 export abstract class BaseQuery<T extends BaseModel, Op extends string, R> {
-	protected abstract applyWhere(key: string, operator: Op, value: any): this;
+	protected abstract applyWhere(key: string | Filter, operator: Op, value: any): this;
+	protected abstract applyWhere(filter: Filter): this;
 	abstract execute(): R;
 
-	where(prop: WhereProp<T>, op: Op, value: any) {
-		return this.applyWhere(this.getWhereProp(prop), op, value);
+	where(propOrFilter: WhereProp<T> | Filter, op?: Op, value?: any) {
+		if (propOrFilter instanceof Filter) {
+			return this.applyWhere(propOrFilter);
+		}
+		return this.applyWhere(this.getWhereProp(propOrFilter), op!, value);
 	}
 
 	whereAll<K extends ModelQuery<T>>(attributes: K | null) {

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "homepage": "https://github.com/freshfox/firestore-storage",
   "dependencies": {
-    "@google-cloud/firestore": "^6.5.0"
+    "@google-cloud/firestore": "^7.11.0"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^2.0.7",

--- a/packages/firestore/src/lib/storage/query.ts
+++ b/packages/firestore/src/lib/storage/query.ts
@@ -5,6 +5,7 @@ import {
 	QuerySnapshot,
 	WhereFilterOp,
 	Query as FSQuery,
+	Filter,
 } from '@google-cloud/firestore';
 import { BaseQuery, BaseModel, WhereProp } from 'firestore-storage-core';
 
@@ -13,10 +14,20 @@ export class Query<T extends BaseModel> extends BaseQuery<T, WhereFilterOp, Prom
 		super();
 	}
 
-	protected applyWhere(key: string, operator: FirebaseFirestore.WhereFilterOp, value: any) {
-		this.base = this.base.where(key, operator, value);
-		return this;
-	}
+	protected applyWhere<K extends string | Filter>(
+        keyOrFilter: K,
+        ...args: K extends string 
+            ? [FirebaseFirestore.WhereFilterOp, any]
+            : []
+    ): this {
+        if (typeof keyOrFilter === 'string') {
+            const [operator, value] = args as [FirebaseFirestore.WhereFilterOp, any];
+            this.base = this.base.where(keyOrFilter, operator, value);
+        } else {
+            this.base = this.base.where(keyOrFilter as Filter);
+        }
+        return this;
+    }
 
 	orderBy(prop: WhereProp<T>, direction: OrderByDirection) {
 		this.base = this.base.orderBy(this.getWhereProp(prop), direction);


### PR DESCRIPTION
# Changes 
- @google/firebase-storage needed a bump to at least 7.8.0 to fix [this](https://github.com/freshfox/firestore-storage/issues/39) issue
- Firestore now allows Filter queries, such as `Filter.or` and `Filter.and` capabilities. The Abstract classes were updated to accommodate these updates